### PR TITLE
Remove FEYN placeholder page

### DIFF
--- a/FEYN.md
+++ b/FEYN.md
@@ -1,1 +1,0 @@
-Nothing here yet, more to come!


### PR DESCRIPTION
FEYN.md was a placeholder ("Nothing here yet, more to come!"). Nothing links to it.