### PR TITLE
Drop the hand-written date line from the Netlight write-up

### DIFF
--- a/Netlight.md
+++ b/Netlight.md
@@ -1,5 +1,3 @@
-*Aug 2026 · 4 min read*
-
 I spent the summer of 2026 as an intern at Netlight, a Nordic technology consultancy. The internship lasted six weeks. I was on the data and AI side of the intern group, and was placed on a project for the World Food Programme's Innovation Accelerator together with one other intern.
 
 ## The project: temporary settlement detection for SKAI+


### PR DESCRIPTION
The note opened with a hand-written `*Aug 2026 · 4 min read*` line, but Quartz's own ContentMeta already renders the date and reading time above the body. The live page therefore showed both, and they disagreed: the generated line says Aug 18, 2026 and 6 min read.

It also cost the page its social preview. Quartz builds the meta description from the first ~150 characters of body text, so the description currently begins "Aug 2026 · 4 min read I spent the summer of 2026...".

No other note carries such a line.