### PR TITLE
Add the Trafikkskiltene write-up

### DIFF
--- a/Trafikkskiltene.md
+++ b/Trafikkskiltene.md
@@ -1,0 +1,17 @@
+Trafikkskiltene.no is a site for learning the Norwegian traffic signs, and the first real project I shipped: I built it when I was sixteen, to learn the signs before my own driving test. It is still live at [trafikkskiltene.no](https://trafikkskiltene.no), and its successor is [Veivett](https://pages.askhb.no/Veivett).
+
+## Built to pass my own test
+
+When I started practising for my licence, I could not find a good, free way to drill the signs, so I made one. The site shows every official sign with its explanation, sourced from Statens vegvesen, and has quizzes, a read-aloud mode, and a page for every sign category. Everything was written by hand, without frameworks.
+
+## What happened next
+
+I passed the test. The site kept going. It found its audience through search, without any marketing, and has since passed 750,000 page views. The advertising on it has earned money every year since launch, with very little maintenance: the site has run largely unchanged for years, through my studies, while I moved on to other work.
+
+## What it taught me
+
+Trafikkskiltene was my real introduction to programming, and to everything around it. JavaScript was my first language, learned by writing this site, together with HTML and CSS. PHP followed, and I learned more of it through later projects. The rest of the education was practical: buying a domain, setting up an Apache web server through cPanel, and learning to manage a live website that people I had never met were using.
+
+Beyond that, it taught me things no course did. Shipping a small thing that answers a real need beats planning a large one. Search traffic compounds when the content genuinely helps. And a website can be a source of income, not only a hobby.
+
+The site teaches the signs, but the theory test is bigger than the signs. In 2026 I rebuilt the idea from scratch as [Veivett](https://pages.askhb.no/Veivett), a study tool for the whole theory test.

--- a/Veivett.md
+++ b/Veivett.md
@@ -2,7 +2,7 @@ Veivett is a study tool for the Norwegian driving theory test, and the successor
 
 ## Where it started
 
-When I was sixteen and about to take my own driving test, I built trafikkskiltene.no to learn the traffic signs. It was plain JavaScript and PHP on an Apache server, and it did one thing: show a sign, take a guess, reveal the answer. It found its audience through search, has passed 750,000 page views, and has earned advertising revenue every year since, with very little maintenance.
+When I was sixteen and about to take my own driving test, I built trafikkskiltene.no to learn the traffic signs. It was plain JavaScript and PHP on an Apache server, and it did one job: teach the signs. It found its audience through search, has passed 750,000 page views, and has earned advertising revenue every year since, with very little maintenance.
 
 It also showed me its own limits. The theory test covers far more than the signs, and on trafikkskiltene a wrong answer taught you nothing except that you were wrong. In 2026 I started over and built the tool I would have wanted: one that covers the whole syllabus and explains itself along the way. The name had to change with the scope, since "trafikkskiltene" literally means "the traffic signs". After checking the company register, the app stores and the domains, the rebuild became Veivett.
 


### PR DESCRIPTION
Adds Trafikkskiltene.md, publishing at pages.askhb.no/Trafikkskiltene: the origin story, what the site does, the traffic and revenue it still earns, and what building it taught me, ending with the handoff to Veivett.

Also adjusts one sentence on the Veivett page so the two pages agree about what the old site did: it now says the site did one job, teaching the signs, instead of underselling it as a bare guess-and-reveal quiz.

Verified with npx quartz build in pages.askhb.no: both pages emit with the intended titles and meta descriptions.